### PR TITLE
Changed New-Subnet to New-IPv4Subnet

### DIFF
--- a/src/SmallsOnline.Subnetting.Pwsh/SmallsOnline.Subnetting.Pwsh.psd1
+++ b/src/SmallsOnline.Subnetting.Pwsh/SmallsOnline.Subnetting.Pwsh.psd1
@@ -73,7 +73,7 @@ FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @(
-    "New-Subnet"
+    "New-IPv4Subnet"
 )
 
 # Variables to export from this module

--- a/src/SmallsOnline.Subnetting.Pwsh/cmdlets/NewIPv4Subnet.cs
+++ b/src/SmallsOnline.Subnetting.Pwsh/cmdlets/NewIPv4Subnet.cs
@@ -6,8 +6,8 @@ namespace SmallsOnline.Subnetting.Pwsh.Cmdlets
 {
     using Lib.Models;
 
-    [Cmdlet(VerbsCommon.New, "Subnet")]
-    public class NewSubnet : PSCmdlet
+    [Cmdlet(VerbsCommon.New, "IPv4Subnet")]
+    public class NewIPv4Subnet : PSCmdlet
     {
         [Parameter(Position = 0, Mandatory = true, ParameterSetName = "Default")]
         [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
Figured this would make it easier to distinguish. Since no IPv6 calculations are done (At least not yet), it makes more sense to call the cmdlet `New-IPv4Subnet`.